### PR TITLE
dependabot github actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,7 @@ updates:
   schedule:
     interval: daily
   open-pull-requests-limit: 10
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: weekly

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
   "require": {
     "php": ">=7.2",
     "broadway/broadway-saga": "^1.0.0",
-    "doctrine/dbal": "^2.6",
+    "doctrine/dbal": "^3.1",
     "beberlei/assert": "^3.0"
   },
   "require-dev": {

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,7 +1,0 @@
-parameters:
-	ignoreErrors:
-		-
-			message: "#^Method Broadway\\\\Saga\\\\State\\\\Dbal\\\\DbalRepository\\:\\:createAndExecuteQuery\\(\\) should return Doctrine\\\\DBAL\\\\Driver\\\\ResultStatement but returns Doctrine\\\\DBAL\\\\ForwardCompatibility\\\\DriverStatement\\|int\\.$#"
-			count: 1
-			path: src/DbalRepository.php
-

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,2 @@
-includes:
-    - phpstan-baseline.neon
-
 parameters:
 	checkMissingIterableValueType: false	

--- a/src/DbalRepository.php
+++ b/src/DbalRepository.php
@@ -109,6 +109,6 @@ class DbalRepository implements RepositoryInterface
             $queryBuilder->setParameter(sprintf('%s', $key), $value);
         }
 
-        return $queryBuilder->execute();
+        return $queryBuilder->executeQuery();
     }
 }

--- a/src/DbalRepository.php
+++ b/src/DbalRepository.php
@@ -18,9 +18,9 @@ use Broadway\Saga\State\Criteria;
 use Broadway\Saga\State\RepositoryException;
 use Broadway\Saga\State\RepositoryInterface;
 use Doctrine\DBAL\Connection;
-use Doctrine\DBAL\Driver\ResultStatement;
 use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
 use Doctrine\DBAL\Query\QueryBuilder;
+use Doctrine\DBAL\Result;
 
 class DbalRepository implements RepositoryInterface
 {
@@ -95,7 +95,7 @@ class DbalRepository implements RepositoryInterface
         }
     }
 
-    protected function createAndExecuteQuery(Criteria $criteria, string $sagaId): ResultStatement
+    protected function createAndExecuteQuery(Criteria $criteria, string $sagaId): Result
     {
         /** @var QueryBuilder $queryBuilder */
         $queryBuilder = $this->connection->createQueryBuilder()

--- a/src/DbalRepository.php
+++ b/src/DbalRepository.php
@@ -102,11 +102,11 @@ class DbalRepository implements RepositoryInterface
             ->select('*')
             ->from($this->tableName)
             ->where('done = :done')
-            ->setParameter(':done', false);
+            ->setParameter('done', false);
 
         foreach ($criteria->getComparisons() as $key => $value) {
             $queryBuilder->andWhere(sprintf('%s = :%s', $key, $key));
-            $queryBuilder->setParameter(sprintf(':%s', $key), $value);
+            $queryBuilder->setParameter(sprintf('%s', $key), $value);
         }
 
         return $queryBuilder->execute();


### PR DESCRIPTION
- Update doctrine/dbal requirement from ^2.6 to ^3.1
- no longer use colon prefix in names parameters
- fixed return type hint
- replaced deprecated method
- Configure Dependabot to update GitHub Actions
